### PR TITLE
remote_read does not work using Python 2.6

### DIFF
--- a/bin/remote_read
+++ b/bin/remote_read
@@ -49,7 +49,7 @@ class BotoMap(object):
   def fetch(self, start, end):
     try:
       return self.key.get_contents_as_string(
-        headers={'Range' : 'bytes={}-{}'.format(start, end)}
+        headers={'Range' : 'bytes={0}-{1}'.format(start, end)}
       )
     except boto.exception.S3ResponseError, e:
       # invalid range, we've reached the end of the file


### PR DESCRIPTION
According to [the docs](http://docs.python.org/2/library/string.html#formatstrings), omitting positional arguments for string formatting was only added in Python 2.7. Simply adding the positional arguments fixed the problem for me on Python 2.6.
